### PR TITLE
Initialize DcvCredentialManager upfront

### DIFF
--- a/nice-dcv/extension.js
+++ b/nice-dcv/extension.js
@@ -119,6 +119,7 @@ class Extension {
 }
 
 function init() {
+    Dcv.getDcvCredentialsManager();
     return new Extension();
 }
 


### PR DESCRIPTION
On the very first time that the user lock its session, only the clock is shown
and the DcvAuthPrompt is not created. If the DcvAuthPrompt is not created, we
don't listen for our UserAuthenticated signal because nobody initialized the
DcvCredentialManager. Thus, the first unlock won't work. Request the
DcvCredentialManager instance on the init phase. Doing so our credential manager
will cache the token and when the DcvAuthPrompt is created it will check for the
token presence and starts the comunication with dcv-graphical-sso service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
