### PR TITLE
DcvShellUserVerifier: Register the credential manager first

### DIFF
--- a/nice-dcv/extension.js
+++ b/nice-dcv/extension.js
@@ -39,6 +39,7 @@ let DcvShellUserVerifier = class DcvShellUserVerifier extends GdmUtil.ShellUserV
         super(client, params);
 
         let dcvCredentialManager = Dcv.getDcvCredentialsManager();
+        this._credentialManagers[Dcv.SERVICE_NAME] = dcvCredentialManager;
         if (dcvCredentialManager.token) {
             this._onCredentialManagerAuthenticated(dcvCredentialManager,
                                                    dcvCredentialManager.token);
@@ -47,8 +48,6 @@ let DcvShellUserVerifier = class DcvShellUserVerifier extends GdmUtil.ShellUserV
         dcvCredentialManager.connectObject('user-authenticated',
                                            this._onCredentialManagerAuthenticated.bind(this),
                                            this);
-
-        this._credentialManagers[Dcv.SERVICE_NAME] = dcvCredentialManager;
     }
 };
 


### PR DESCRIPTION
Do it for consistency with the GNOME Shell code base.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
