### PR TITLE
Call uninhibit_remote_access() first

### DIFF
--- a/nice-dcv/extension.js
+++ b/nice-dcv/extension.js
@@ -54,6 +54,8 @@ class Extension {
     enable() {
         GdmUtil.ShellUserVerifier = DcvShellUserVerifier;
 
+        // FIXME: Remove this code once we have headless sessions.
+        this._remoteAccessController.uninhibit_remote_access();
         this._remoteAccessController.inhibit_remote_access = () => {};
         this._remoteAccessController.uninhibit_remote_access = () => {};
 


### PR DESCRIPTION
So that if the session is already inhibited before our extension gets loaded we are able to unhinibit it. This might cause the following warning:
```
gnome-shell[569500]: meta_dbus_session_manager_uninhibit: assertion 'priv->inhibit_count > 0' failed
```
But we are fine with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
