### PR TITLE
dcv: Adapt to multiple sessions

### DIFF
--- a/dcv/dcv.js
+++ b/dcv/dcv.js
@@ -19,6 +19,7 @@
 
 import Gio from 'gi://Gio';
 import * as Credential from 'resource:///org/gnome/shell/gdm/credentialManager.js';
+import * as ObjectManager from 'resource:///org/gnome/shell/misc/objectManager.js';
 
 const dbusName = 'com.nicesoftware.DcvServer'
 const dbusPath = '/com/nicesoftware/DcvServer';
@@ -29,15 +30,47 @@ export const SERVICE_NAME = 'dcv-graphical-sso';
 const DcvCredentialsIface = `<node>
 <interface name="${dbusInterface}">
 <signal name="UserAuthenticated">
+    <arg type="s" name="session"/>
     <arg type="s" name="token"/>
 </signal>
 </interface>
 </node>`;
-
-
 const DcvCredentialsInfo = Gio.DBusInterfaceInfo.new_for_xml(DcvCredentialsIface);
 
-let _dcvCredentialsManager = null;
+const GdmRemoteDisplayIface = `
+<node>
+<interface name="org.gnome.DisplayManager.RemoteDisplay">
+  <property name="SessionId" type="s" access="read"/>
+  <property name="RemoteId" type="o" access="read"/>
+</interface>
+</node>
+`;
+
+let _dcvCredentialsManagers = new Map();
+
+function parseRemoteIdToDcvSessionId(remoteId) {
+    const prefix = '/com/amazon/dcv/';
+    if (!remoteId || !remoteId.startsWith(prefix)) {
+        return null;
+    }
+
+    const encodedId = remoteId.substring(prefix.length);
+    if (encodedId.length % 2 !== 0) {
+        return null;
+    }
+
+    let decodedId = '';
+    for (let i = 0; i < encodedId.length; i += 2) {
+        const hexByte = encodedId.substring(i, i + 2);
+        const charCode = parseInt(hexByte, 16);
+        if (isNaN(charCode)) {
+            return null;
+        }
+        decodedId += String.fromCharCode(charCode);
+    }
+
+    return decodedId;
+}
 
 function DcvCredentials() {
     var self = new Gio.DBusProxy({
@@ -53,22 +86,71 @@ function DcvCredentials() {
 }
 
 var DcvCredentialsManager = class DcvCredentialsManager extends Credential.CredentialManager {
-    constructor() {
+    constructor(sessionId) {
         super(SERVICE_NAME);
-        this._credentials = new DcvCredentials();
-        this._credentials.connectSignal('UserAuthenticated',
-            (proxy, sender, [token]) => {
-                this.token = token;
-            });
+        this._dcvSessionId = null;
+
+        this._objectManager = new ObjectManager.ObjectManager({
+            connection: Gio.DBus.system,
+            name: 'org.gnome.DisplayManager',
+            objectPath: '/org/gnome/DisplayManager/Displays',
+            knownInterfaces: [GdmRemoteDisplayIface],
+            onLoaded: () => {
+                const remoteDisplays = this._objectManager.getProxiesForInterface('org.gnome.DisplayManager.RemoteDisplay');
+                for (const display of remoteDisplays) {
+                    if (display.SessionId !== sessionId) {
+                        continue;
+                    }
+
+                    const remoteId = display.RemoteId;
+                    const dcvSessionId = parseRemoteIdToDcvSessionId(remoteId);
+                    if (dcvSessionId === null) {
+                        // Despite being the right remote display, this is not managed by DCV.
+                        return;
+                    }
+
+                    this._dcvSessionId = dcvSessionId;
+                    break;
+                }
+
+                const sessionType = this._dcvSessionId ? 'virtual' : 'console';
+                const sessionName = this._dcvSessionId ? ` name: '${this._dcvSessionId}'` : '';
+                console.log(`${SERVICE_NAME}: DCV session type '${sessionType}'${sessionName}`);
+
+                this._credentials = new DcvCredentials();
+                this._credentials.connectSignal('UserAuthenticated', this._onUserAuthenticated.bind(this));
+            }
+        });
+    }
+
+    _onUserAuthenticated(proxy, sender, [session, token]) {
+        if (this._dcvSessionId === null) {
+            const remoteDisplays = this._objectManager.getProxiesForInterface('org.gnome.DisplayManager.RemoteDisplay');
+            for (const display of remoteDisplays) {
+                const dcvSessionId = parseRemoteIdToDcvSessionId(display.RemoteId);
+                if (dcvSessionId !== null) {
+                    // We are a console session and there is at least one
+                    // DCV virtual session, don't log in.
+                    return;
+                }
+            }
+        }
+
+        if (this._dcvSessionId !== null && this._dcvSessionId !== session) {
+            return;
+        }
+
+        this.token = token;
     }
 };
 
 /**
  * @returns {DcvCredentialsManager}
  */
-export function getDcvCredentialsManager() {
-    if (!_dcvCredentialsManager)
-        _dcvCredentialsManager = new DcvCredentialsManager();
+export function getDcvCredentialsManager(sessionId) {
+    if (!_dcvCredentialsManagers.has(sessionId)) {
+        _dcvCredentialsManagers.set(sessionId, new DcvCredentialsManager(sessionId));
+    }
 
-    return _dcvCredentialsManager;
+    return _dcvCredentialsManagers.get(sessionId);
 }

--- a/dcv/extension.js
+++ b/dcv/extension.js
@@ -21,26 +21,35 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as AuthPrompt from 'resource:///org/gnome/shell/gdm/authPrompt.js';
 import * as GdmUtil from 'resource:///org/gnome/shell/gdm/util.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+
+const SystemdLoginSessionIface = `
+<node>
+<interface name="org.freedesktop.login1.Session">
+  <property name="Id" type="s" access="read"/>
+  <property name="Remote" type="b" access="read"/>
+</interface>
+</node>
+`;
+
+const SystemdLoginSession = Gio.DBusProxy.makeProxyWrapper(SystemdLoginSessionIface);
 
 import * as Dcv from './dcv.js';
 
 let DcvShellUserVerifier = class DcvShellUserVerifier extends GdmUtil.ShellUserVerifier {
-    constructor(client, params) {
+    constructor(client, params, sessionId) {
         super(client, params);
-        this.addCredentialManager(Dcv.SERVICE_NAME, Dcv.getDcvCredentialsManager());
+        this.addCredentialManager(Dcv.SERVICE_NAME, Dcv.getDcvCredentialsManager(sessionId));
     }
 };
-
-function _createDcvUserVerifier(gdmClient, params) {
-    return new DcvShellUserVerifier(gdmClient, params);
-}
 
 export default class DcvExtension extends Extension {
     constructor(metadata) {
         super(metadata);
 
         if (AuthPrompt.AuthPrompt.prototype._createUserVerifier === undefined) {
-            console.log(`${this.metadata.name} not supported`);
+            console.log(`${this.metadata.name}: Not supported`);
             this._supported = false;
             return;
         }
@@ -53,6 +62,36 @@ export default class DcvExtension extends Extension {
         this._originalUninhibit = this._remoteAccessController.uninhibit_remote_access;
     }
 
+    _uninhibitRemoteAccess() {
+        this._remoteAccessController.uninhibit_remote_access();
+        this._remoteAccessController.inhibit_remote_access = () => {};
+        this._remoteAccessController.uninhibit_remote_access = () => {};
+    }
+
+    _inhibitRemoteAccess() {
+        this._remoteAccessController.inhibit_remote_access();
+        this._remoteAccessController.inhibit_remote_access = this._originalInhibit;
+        this._remoteAccessController.uninhibit_remote_access = this._originalUninhibit;
+    }
+
+    /* We should use LoginManager::getCurrentSessionProxy() from GNOME Shell for simplicity but it is
+     * buggy. Use our own implementation until this commit is ubiquitous:
+     * https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/5db3a2b7bcfebdcc71038df890ae44308c98b95e
+     */
+    async getCurrentSessionProxy() {
+        if (this._currentSession)
+            return this._currentSession;
+
+        try {
+            this._currentSession = await SystemdLoginSession.newAsync(
+                Gio.DBus.system, 'org.freedesktop.login1', '/org/freedesktop/login1/session/auto');
+            return this._currentSession;
+        } catch (error) {
+            console.error(`${this.metadata.name}: Could not get a proxy for the current session: ${error}`);
+            return null;
+        }
+    }
+
     enable() {
         if (!this._supported) {
             Main.notifyError(`Unable to load '${this.metadata.name}'`,
@@ -60,18 +99,32 @@ export default class DcvExtension extends Extension {
             return;
         }
 
-        AuthPrompt.AuthPrompt.prototype._createUserVerifier = _createDcvUserVerifier;
+        this.getCurrentSessionProxy().then(session => {
+            if (!session) {
+                console.error(`${this.metadata.name}: Could not get session proxy`);
+                return;
+            }
 
-        // FIXME: Remove this code once we have headless sessions.
-        this._remoteAccessController.uninhibit_remote_access();
-        this._remoteAccessController.inhibit_remote_access = () => {};
-        this._remoteAccessController.uninhibit_remote_access = () => {};
+            const sessionId = session.Id;
+            const sessionRemote = session.Remote;
+            console.log(`${this.metadata.name}: Session '${sessionId}', Remote '${sessionRemote}'`);
 
-        if (Main.screenShield) {
-            Main.screenShield.addCredentialManager(Dcv.SERVICE_NAME, Dcv.getDcvCredentialsManager());
-        }
+            if (!sessionRemote) {
+                // For headless sessions we don't need to uninhibit remote access
+                // because it is allowed by default.
+                this._uninhibitRemoteAccess();
+            }
 
-        console.log(`${this.metadata.name} enabled`);
+            AuthPrompt.AuthPrompt.prototype._createUserVerifier = (gdmClient, params) => {
+                return new DcvShellUserVerifier(gdmClient, params, sessionId);
+            };
+
+            if (Main.screenShield) {
+                Main.screenShield.addCredentialManager(Dcv.SERVICE_NAME, Dcv.getDcvCredentialsManager(sessionId));
+            }
+
+            console.log(`${this.metadata.name}: Enabled`);
+        });
     }
 
     disable() {
@@ -80,14 +133,12 @@ export default class DcvExtension extends Extension {
         }
 
         AuthPrompt.AuthPrompt.prototype._createUserVerifier = this._originalCreateUserVerifier;
-        this._remoteAccessController.inhibit_remote_access = this._originalInhibit;
-        this._remoteAccessController.uninhibit_remote_access = this._originalUninhibit;
+        this._inhibitRemoteAccess();
 
         if (Main.screenShield) {
             Main.screenShield.removeCredentialManager(Dcv.SERVICE_NAME);
         }
 
-        console.log(`${this.metadata.name} disabled`);
+        console.log(`${this.metadata.name}: Disabled`);
     }
 }
-


### PR DESCRIPTION
There are going to be multiple GNOME Shell instances running that will listen to the UserAuthenticated signal. Pass the DCV session ID as a parameter to allow each instance to detect whether it should react to that signal. To detect this, each GNOME Shell extension should be aware of which DCV session it is running in. Take this into account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
